### PR TITLE
Change build-essentials to build-essential

### DIFF
--- a/ubuntu-install.sh
+++ b/ubuntu-install.sh
@@ -6,7 +6,7 @@ for_neovim="software-properties-common python-dev python-pip python3-dev python3
 npm_modules="js-beautify node-sass less csslint eslint"
 
 #required beforehand(to be figured out why)
-apt-get install -y build-essentials
+apt-get install -y build-essential
 
 #adding PPA for neovim
 add-apt-repository ppa:neovim-ppa/unstable


### PR DESCRIPTION
Ran into the error - `    Unable to locate package build-essentials`

Changing the command to `sudo apt-get install build-essential` worked

Refer to https://stackoverflow.com/questions/6486449/using-sudo-apt-get-install-build-essentials